### PR TITLE
Add test-case for curl ipfs:// integrity controls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,9 @@ jobs:
           - path: contrib/plot-rustup.yaml
           - path: contrib/plot-signal-desktop.yaml
           - path: contrib/plot-terraform.yaml
+          - path: contrib/plot-curl-ipfs.yaml
+            args: '-B 0.0.0.0:443'
+            sudo: 'sudo'
 
     name: ${{ matrix.plot.path }}
     runs-on: ubuntu-22.04

--- a/contrib/plot-curl-ipfs.yaml
+++ b/contrib/plot-curl-ipfs.yaml
@@ -1,0 +1,35 @@
+---
+
+upstreams:
+  ipfs_io:
+    url: https://ipfs.io/
+
+tls:
+  names: ["ipfs.io"]
+
+check:
+  image: archlinux
+  install_certs: ['tee', '-a', '/etc/ssl/certs/ca-certificates.crt']
+  register_hosts:
+    - ipfs.io
+  cmds:
+    # installing from git since feature is not released yet
+    - pacman -Suy --noconfirm base-devel git openssl
+    - git clone --depth=1 https://github.com/curl/curl
+    - cd /curl; autoreconf -fi
+    - cd /curl; ./configure --with-openssl --with-random=/dev/urandom
+    - make -C curl
+    - mkdir -p "$HOME/.ipfs"
+    - echo https://ipfs.io > "$HOME/.ipfs/gateway"
+    # Hello World
+    - curl/src/curl -sSvf ipfs://QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u
+
+routes:
+  - path: "/ipfs/QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u"
+    type: static
+    args:
+      data: |
+        IPFS response has been tampered with 😈
+  - type: proxy
+    args:
+      upstream: ipfs_io


### PR DESCRIPTION
This tests integrity controls in the ipfs integration of curl. At the time of writing it seems there's full trust in the ipfs gateway, as demonstrated by this example plot:

```sh
sudo sh4d0wup check contrib/plot-curl-ipfs.yaml -B 0.0.0.0:443
```

sh4d0wup acts as a malicious ipfs gateway, resulting in this:

```
$ curl -sSf ipfs://QmWATWQ7fVPP2EFGu71UkfnqhYXDYH566qy47CnJDgvs8u
IPFS response has been tampered with 😈
```

In ipfs there's a concept of [trustless gateways](https://docs.ipfs.tech/reference/http/gateway/#trusted-vs-trustless), but I'm not sure [CAR](https://docs.ipfs.tech/concepts/glossary/#car) and [`ipfs-car`](https://github.com/web3-storage/ipfs-car) support responses that are both authenticated and still streamed.

This may or may not be a problem for you, curl is assuming the gateway runs on the local computer and is therefore as trustworthy as the curl process itself.